### PR TITLE
Automatic style links refactored to inline style

### DIFF
--- a/doc/big-data-analysis-of-historic-context-information/deep-dive.md
+++ b/doc/big-data-analysis-of-historic-context-information/deep-dive.md
@@ -1,11 +1,11 @@
 Should you wish to learn much more about this, please check: 
    
    - Cygnus:
-       - Github repository (reference implementation)  <https://github.com/Fiware/context.Cygnus>
-       - Play with the Docker container <https://hub.docker.com/r/fiware/cygnus/>
-       - Read the full documentation <http://fiware-cygnus.readthedocs.org/en/latest/>
-       - Latest stable release <https://github.com/Fiware/context.Cygnus/releases/tag/release-0.12.0> 
+       - [Github repository (reference implementation)](https://github.com/Fiware/context.Cygnus)
+       - [Play with the Docker container](https://hub.docker.com/r/fiware/cygnus/)
+       - [Read the full documentation](http://fiware-cygnus.readthedocs.org/en/latest/)
+       - [Latest stable release](https://github.com/Fiware/context.Cygnus/releases/tag/release-0.12.0)
    - Cosmos:
-       - Github repository (reference implementation)  <https://github.com/Fiware/context.Cosmos>
-       - Read the full documentation <http://fiware-cosmos.readthedocs.org/en/latest/>
-       - Latest stable release <https://github.com/Fiware/context.Cosmos/releases/tag/release-0.2.0>
+       - [Github repository (reference implementation)](https://github.com/Fiware/context.Cosmos)
+       - [Read the full documentation](http://fiware-cosmos.readthedocs.org/en/latest/)
+       - [Latest stable release](https://github.com/Fiware/context.Cosmos/releases/tag/release-0.2.0)

--- a/doc/connection-to-the-internet-of-things/deep-dive.md
+++ b/doc/connection-to-the-internet-of-things/deep-dive.md
@@ -1,8 +1,8 @@
 Should you wish to learn much more about this, please check: 
 
-   - Github repository (reference implementation)  <https://github.com/Fiware/iot.IoTAgent-Cplusplus>
-   - Play with the Docker container <https://hub.docker.com/r/fiware/fiware-iotagent-cplusplus/>
-   - Browse the API <http://docs.telefonicaiotiotagents.apiary.io>
-   - Read the full documentation <http://fiware-iot-stack.readthedocs.org/en/latest/>
-   - Latest stable release <https://github.com/Fiware/iot.IoTAgent-Cplusplus/releases/tag/1.3.0%2FKO>
+   - [Github repository (reference implementation)](https://github.com/Fiware/iot.IoTAgent-Cplusplus)
+   - [Play with the Docker container](https://hub.docker.com/r/fiware/fiware-iotagent-cplusplus/)
+   - [Browse the API](http://docs.telefonicaiotiotagents.apiary.io)
+   - [Read the full documentation](http://fiware-iot-stack.readthedocs.org/en/latest/)
+   - [Latest stable release](https://github.com/Fiware/iot.IoTAgent-Cplusplus/releases/tag/1.3.0%2FKO)
 

--- a/doc/creating-application-dashboards/deep-dive.md
+++ b/doc/creating-application-dashboards/deep-dive.md
@@ -1,7 +1,7 @@
 Should you wish to learn much more about this, please check: 
 
-   - Github repository (reference implementation)  <https://github.com/Fiware/apps.Wirecloud>
-   - Play with the Docker container <https://hub.docker.com/r/fiware/wirecloud/>
-   - Browse the API <http://docs.fiwareapplicationmashup.apiary.io>
-   - Read the full documentation <http://wirecloud.readthedocs.org/en/latest/>
-   - Latest stable release <https://github.com/Fiware/apps.Wirecloud/releases/tag/0.9.0>
+   - [Github repository (reference implementation)](https://github.com/Fiware/apps.Wirecloud)
+   - [Play with the Docker container](https://hub.docker.com/r/fiware/wirecloud/)
+   - [Browse the API](http://docs.fiwareapplicationmashup.apiary.io)
+   - [Read the full documentation](http://wirecloud.readthedocs.org/en/latest/)
+   - [Latest stable release](https://github.com/Fiware/apps.Wirecloud/releases/tag/0.9.0)

--- a/doc/development-context-aware-applications/deep-dive.md
+++ b/doc/development-context-aware-applications/deep-dive.md
@@ -1,9 +1,9 @@
 Should you wish to learn much more about this, please check: 
 
-   - Github repository (reference implementation)  <https://github.com/Fiware/context.Orion>
-   - Play with the Docker container <https://hub.docker.com/r/fiware/orion/>
-   - Browse the API v1 <http://fiware.github.io/context.Orion/api/v1/>:
-   - Browse the API v2 <http://fiware.github.io/context.Orion/api/v2/>
-   - Browse the API cookbook <http://fiware.github.io/context.Orion/api/v2/cookbook/>
-   - Read the full documentation <http://fiware-orion.readthedocs.org/en/latest/>
-   - Latest stable release <https://github.com/Fiware/context.Orion/releases/tag/1.0.0>
+   - [Github repository (reference implementation) ](https://github.com/Fiware/context.Orion)
+   - [Play with the Docker container](https://hub.docker.com/r/fiware/orion/)
+   - [Browse the API v1](http://fiware.github.io/context.Orion/api/v1/)
+   - [Browse the API v2](http://fiware.github.io/context.Orion/api/v2/)
+   - [Browse the API cookbook](http://fiware.github.io/context.Orion/api/v2/cookbook/)
+   - [Read the full documentation](http://fiware-orion.readthedocs.org/en/latest/)
+   - [Latest stable release](https://github.com/Fiware/context.Orion/releases/tag/1.0.0)

--- a/doc/handling-authorization-and-access-control-to-apis/deep-dive.md
+++ b/doc/handling-authorization-and-access-control-to-apis/deep-dive.md
@@ -1,18 +1,18 @@
 Should you wish to learn much more about this, please check:
  
    - IdM
-       - Github repository (reference implementation)  <https://github.com/Fiware/security.Idm>
-       - Play with the Docker container <https://hub.docker.com/r/fiware/idm/>
-       - Browse the API <http://docs.keyrock.apiary.io/>
-       - Read the full documentation <http://fiware-idm.readthedocs.org/en/latest/>
-       - Latest stable release <https://github.com/Fiware/security.Idm/releases/tag/v5.1.1> 
+       - [Github repository (reference implementation)](https://github.com/Fiware/security.Idm)
+       - [Play with the Docker container](https://hub.docker.com/r/fiware/idm/)
+       - [Browse the API](http://docs.keyrock.apiary.io/)
+       - [Read the full documentation](http://fiware-idm.readthedocs.org/en/latest/)
+       - [Latest stable release](https://github.com/Fiware/security.Idm/releases/tag/v5.1.1)
    - AuthzForce
-       - Github repository (reference implementation)  <https://github.com/Fiware/security.AuthZForce>
-       - Play with the Docker container <https://hub.docker.com/r/fiware/authzforce-ce-server/>
-       - Read the full documentation <http://authzforce-ce-fiware.readthedocs.org/en/latest/>
-       - Latest stable release <https://github.com/authzforce/server/releases/tag/release-4.4.0> 
+       - [Github repository (reference implementation)](https://github.com/Fiware/security.AuthZForce)
+       - [Play with the Docker container](https://hub.docker.com/r/fiware/authzforce-ce-server/)
+       - [Read the full documentation](http://authzforce-ce-fiware.readthedocs.org/en/latest/)
+       - [Latest stable release](https://github.com/authzforce/server/releases/tag/release-4.4.0)
    - Pep-proxy
-       - Github repository (reference implementation)  <https://github.com/Fiware/security.Pep-proxy>
-       - Play with the Docker container <https://hub.docker.com/r/fiware/pep-proxy/>
-       - Read the full documentation <http://fiware-pep-proxy.readthedocs.org/en/stable/>
-       - Latest stable release <https://github.com/Fiware/security.Pep-proxy/releases/tag/5.1>
+       - [Github repository (reference implementation)](https://github.com/Fiware/security.Pep-proxy)
+       - [Play with the Docker container](https://hub.docker.com/r/fiware/pep-proxy/)
+       - [Read the full documentation](http://fiware-pep-proxy.readthedocs.org/en/stable/)
+       - [Latest stable release](https://github.com/Fiware/security.Pep-proxy/releases/tag/5.1)

--- a/doc/providing-an-advanced-user-experience-ux/deep-dive.md
+++ b/doc/providing-an-advanced-user-experience-ux/deep-dive.md
@@ -1,34 +1,34 @@
 Should you wish to learn much more about this, please check: 
 
    - XML3D:
-      - Github repository (reference implementation)  <https://github.com/Fiware/webui.XML3D>
-      - Read the full documentation <https://xml3d.readthedocs.org/en/latest>
-      - Latest stable release <https://github.com/Fiware/webui.XML3D/releases/tag/5.1.4> 
+      - [Github repository (reference implementation)](https://github.com/Fiware/webui.XML3D)
+      - [Read the full documentation](https://xml3d.readthedocs.org/en/latest)
+      - [Latest stable release](https://github.com/Fiware/webui.XML3D/releases/tag/5.1.4) 
 
    - webtundra: 
-      - Github repository (reference implementation)  <https://github.com/Fiware/webui.WebTundra3D>
-      - Play with the Docker container <https://hub.docker.com/r/adminotech/webtundra/>
-      - Read the full documentation <http://webtundra.readthedocs.org/en/latest/>
-      - Latest stable release <https://github.com/Fiware/webui.WebTundra3D/releases/tag/5.1.3> 
+      - [Github repository (reference implementation)](https://github.com/Fiware/webui.WebTundra3D)
+      - [Play with the Docker container](https://hub.docker.com/r/adminotech/webtundra/)
+      - [Read the full documentation](http://webtundra.readthedocs.org/en/latest/)
+      - [Latest stable release](https://github.com/Fiware/webui.WebTundra3D/releases/tag/5.1.3) 
    
    - POI Data Provider: 
-      - Github repository (reference implementation)  <https://github.com/Fiware/webui.POIDataProvider>
-      - Play with the Docker container <https://hub.docker.com/r/ariokkon/fiware_poi_dataprovider/>
-      - Latest stable release <https://github.com/Fiware/webui.POIDataProvider/releases/tag/r5.1>    
+      - [Github repository (reference implementation)](https://github.com/Fiware/webui.POIDataProvider)
+      - [Play with the Docker container](https://hub.docker.com/r/ariokkon/fiware_poi_dataprovider/)
+      - [Latest stable release](https://github.com/Fiware/webui.POIDataProvider/releases/tag/r5.1)    
 
    - Synchronization: 
       - Tundra version:
-         - Github repository (reference implementation)  <https://github.com/Fiware/webui.Synchronization.Tundra>
-         - Play with the Docker container <https://hub.docker.com/r/loorni/synchronization/>
-         - Browse the API <http://docs.sceneapi.apiary.io/>
-         - Read the full documentation <http://synchronization.readthedocs.org/en/latest/>
-         - Latest stable release <https://github.com/Fiware/webui.Synchronization.Tundra/releases/tag/tundra2.5.4> 
+         - [Github repository (reference implementation)](https://github.com/Fiware/webui.Synchronization.Tundra)
+         - [Play with the Docker container](https://hub.docker.com/r/loorni/synchronization/)
+         - [Browse the API](http://docs.sceneapi.apiary.io/)
+         - [Read the full documentation](http://synchronization.readthedocs.org/en/latest/)
+         - [Latest stable release](https://github.com/Fiware/webui.Synchronization.Tundra/releases/tag/tundra2.5.4) 
       - FiVES version:
-         - Github repository (reference implementation)  <https://github.com/Fiware/webui.Synchronization.FivES>
-         - Play with the Docker container <https://hub.docker.com/r/tospie/fives/>
-         - Browse the API <http://docs.sceneapi.apiary.io/>
-         - Read the full documentation <http://fives.readthedocs.org/en/latest/ >
-         - Latest stable release <https://github.com/Fiware/webui.Synchronization.FivES/releases/tag/fiware-4.4.1> 
+         - [Github repository (reference implementation)](https://github.com/Fiware/webui.Synchronization.FivES)
+         - [Play with the Docker container](https://hub.docker.com/r/tospie/fives/)
+         - [Browse the API](http://docs.sceneapi.apiary.io/)
+         - [Read the full documentation](http://fives.readthedocs.org/en/latest/ )
+         - [Latest stable release](https://github.com/Fiware/webui.Synchronization.FivES/releases/tag/fiware-4.4.1) 
 
 
 

--- a/doc/publishing-open-data-in-fiware/deep-dive.md
+++ b/doc/publishing-open-data-in-fiware/deep-dive.md
@@ -1,7 +1,7 @@
 Should you wish to learn much more about this, please check: 
 
-   - Github repository (reference implementation)  <https://github.com/Fiware/context.Ckan>
-   - Play with the Docker container <https://hub.docker.com/r/fiware/ckan/>
-   - Browse the API <http://docs.ckan.apiary.io/>
-   - Read the full documentation <http://docs.ckan.org/en/latest/>
-   - Latest stable release <https://github.com/Fiware/context.Ckan/releases/tag/ckan-2.5.2>
+   - [Github repository (reference implementation)](https://github.com/Fiware/context.Ckan)
+   - [Play with the Docker container](https://hub.docker.com/r/fiware/ckan/)
+   - [Browse the API](http://docs.ckan.apiary.io/)
+   - [Read the full documentation](http://docs.ckan.org/en/latest/)
+   - [Latest stable release](https://github.com/Fiware/context.Ckan/releases/tag/ckan-2.5.2)

--- a/doc/real-time-processing-of-context-events/deep-dive.md
+++ b/doc/real-time-processing-of-context-events/deep-dive.md
@@ -1,6 +1,6 @@
 Should you wish to learn much more about this, please check: 
 
-   - Github repository (reference implementation)  <https://github.com/Fiware/context.Proton>
-   - Play with the Docker container <https://hub.docker.com/r/fiware/proactivetechnologyonline/>
-   - Read the full documentation <http://proactive-technology-online.readthedocs.org/en/latest/>
-   - Latest stable release <https://github.com/Fiware/context.Proton/releases/tag/v4.4.1>
+   - [Github repository (reference implementation)](https://github.com/Fiware/context.Proton)
+   - [Play with the Docker container](https://hub.docker.com/r/fiware/proactivetechnologyonline/)
+   - [Read the full documentation](http://proactive-technology-online.readthedocs.org/en/latest/)
+   - [Latest stable release](https://github.com/Fiware/context.Proton/releases/tag/v4.4.1)

--- a/doc/real-time-processing-of-media-streams/deep-dive.md
+++ b/doc/real-time-processing-of-media-streams/deep-dive.md
@@ -1,8 +1,8 @@
 Should you wish to learn much more about this, please check: 
 
-   - Github repository (reference implementation)  <https://github.com/Fiware/context.Kurento>
-   - Play with the Docker container <https://hub.docker.com/r/fiware/stream-oriented-kurento/>
-   - Browse the API <http://docs.streamoriented.apiary.io/>
-   - Read the full documentation <http://kurento.readthedocs.org/en/latest/>
-   - Latest stable release <https://github.com/Kurento/kurento-media-server/releases/tag/6.4.0>
+   - [Github repository (reference implementation)](https://github.com/Fiware/context.Kurento)
+   - [Play with the Docker container](https://hub.docker.com/r/fiware/stream-oriented-kurento/)
+   - [Browse the API](http://docs.streamoriented.apiary.io/)
+   - [Read the full documentation](http://kurento.readthedocs.org/en/latest/)
+   - [Latest stable release](https://github.com/Kurento/kurento-media-server/releases/tag/6.4.0)
 


### PR DESCRIPTION
This pull request changes the url format used in the *deep dive sections* from `text <url>`  to ` [text](url)`

A compiled version is available online at <http://testfiwaretour.readthedocs.org/en/refactor-deep_dive_url/>