### PR TITLE
updated orion documentation with tourguide examples.

### DIFF
--- a/doc/development-context-aware-applications/how-to-connect-to-external-context-providers.md
+++ b/doc/development-context-aware-applications/how-to-connect-to-external-context-providers.md
@@ -24,26 +24,19 @@ advantages:
 
 Let’s illustrate with an example based on the NiceEating case. Let’s
 consider an external restaurant booking system that is able to provide
-in real time the number of free places of a given restaurant and
-occupancy level (as a percentage). That system runs at
+in real time the occupancy level (as an absolute value). That system runs at
 http://booking.restaurants.foo.com and plays the role of a Context
 Provider.
 
-First, the Context Provider is registered as provider of free\_places
-and occupancy\_level for “LeBistro” restaurant:
+First, the Context Provider is registered as provider of `occupancyLevels` for Elizalde restaurant which id is `0115206c51f60b48b77e4c937835795c33bb953f`:
 
-    POST <cb_host>:<cb_port>/v1/registry/contextEntities/type/Restaurant/id/LeBistro/attributes/free_places
-    {
-      "duration" : "P1M",
-      "providingApplication" : "http://booking.restaurants.foo.com"
-    }
-    POST <cb_host>:<cb_port>/v1/registry/contextEntities/type/Restaurant/id/LeBistro/attributes/occupancy_level
+    POST <cb_host>:<cb_port>/v1/registry/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f/attributes/occupancyLevels
     {
       "duration" : "P1M",
       "providingApplication" : "http://booking.restaurants.foo.com"
     }
 
-Thus, each time free\_places or occupancy\_level is queried at Context
+Thus, each time `occupancyLevels` is queried at Context
 Broker GE (e.g. from the user smartphone application), that query is
 forwarded to http://booking.restaurants.foo.com. From a Context Consumer
 perspective, all the process is transparent, as if the information were

--- a/doc/development-context-aware-applications/how-to-perform-geo-located-queries.md
+++ b/doc/development-context-aware-applications/how-to-perform-geo-located-queries.md
@@ -2,30 +2,84 @@ One very powerful feature in Context Broker GE is the ability to perform
 geo-located queries. You can query entities located inside (or outside)
 a region defined by a circle or a polygon.  
  For example, to query for all the restaurants within 13 km of the
-Madrid city center (identified by GPS coordinates 40.418889, -3.691944)
+Victoria Gasteiz city center (identified by GPS coordinates 42.846718, -2.671635)
 a Context Consumer application will use the following query:
 
     POST <cb_host>:<cb_port>/v1/queryContext
     {
-        "entities": [
-            {
-                "type": "Restaurant",
-                "isPattern": "true",
-                "id": ".*"
-            }
-        ],
-        "restriction": {
-            "scopes": [
-                {
-                    "type": "FIWARE::Location",
-                    "value": {
-                        "circle": {
-                            "centerLatitude": "40.418889",
-                            "centerLongitude": "-3.691944",
-                            "radius": "13000"
-                        }
-                    }
-                }
-            ]
+      "entities": [
+        {
+          "type": "Restaurant",
+          "isPattern": "true",
+          "id": ".*"
         }
+      ],
+      "restriction": {
+        "scopes": [
+          {
+            "type": "FIWARE::Location",
+            "value": {
+              "circle": {
+                "centerLatitude": 42.846718,
+                "centerLongitude": -2.671635,
+                "radius": "13000"
+              }
+            }
+          }
+        ]
+      }
     }
+
+
+
+To query for all restaurants inside a defined zone inside Victoria Gasteiz a Context Consumer application will use the following query: 
+
+
+    POST <cb_host>:<cb_port>/v1/queryContext
+    {
+      "entities": [
+        {
+          "type": "Restaurant",
+          "isPattern": "true",
+          "id": ".*"
+        }
+      ],
+      "restriction": {
+        "scopes":[
+          {
+            "type": "FIWARE::Location",
+            "value": {
+              "polygon": {
+                "vertices": [
+                  {
+                    "latitude": 42.847476,
+                    "longitude": -2.763969
+                  },
+                  {
+                    "latitude": 42.826006,
+                    "longitude": -2.743151
+                  },
+                  {
+                    "latitude": 42.826485,
+                    "longitude":  -2.653740
+                  },
+                  {
+                    "latitude": 42.867061,
+                    "longitude": -2.630934
+                  },
+                  {
+                    "latitude":  42.881801,
+                    "longitude":  -2.640617
+                  },
+                  {
+                    "latitude":   42.867767,
+                    "longitude":   -2.726723
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+

--- a/doc/development-context-aware-applications/how-to-subscribe-to-changes-on-context-information.md
+++ b/doc/development-context-aware-applications/how-to-subscribe-to-changes-on-context-information.md
@@ -6,56 +6,56 @@ Broker GE is “programmed” to send notifications upon given conditions
 (specified in the subscription request).
 
 In the case of NiceEating, the application backend could use a
-subscription so each time a new rating is cast by any user, the backend
+subscription so each time a new review is cast by any user, the backend
 gets notified (in order to recalculate restaurant average score and
 publish it back in the Context Broker GE).
 
     POST <cb_host>:<cb_port>/v1/subscribeContext
     {
-        "entities": [
-            {
-                "type": "Rating",
-                "isPattern": "true",
-                "id": ".*"
-            }
-        ],
-        "attributes": [ "score"  ],
-        "reference": "http://backend.niceeating.foo.com:1028/ratings",
-        "duration": "P1M",
-        "notifyConditions": [
-            {
-                "type": "ONCHANGE",
-                "condValues": [
-                    "score"
-                ]
-            }
-        ]
+      "entities": [
+        {
+          "type": "Review",
+          "isPattern": "true",
+          "id": ".*"
+        }
+      ],
+      "attributes": [ "ratingValue"  ],
+      "reference": "http://backend.niceeating.foo.com:1028/ratings",
+      "duration": "P1M",
+      "notifyConditions": [
+        {
+          "type": "ONCHANGE",
+          "condValues": [
+              "ratingValue"
+          ]
+        }
+      ]
     }
 
 Another case would be an application that subscribes to changes in
 average ratings of a given restaurant. This may be useful for restaurant
-owners in other to know how their restaurants score is evolving.
-
+owners in order to know how their restaurants score is evolving. In this example a subscription to the restaurant Elizalde which id is `0115206c51f60b48b77e4c937835795c33bb953f` is performed:
+  
     POST <cb_host>:<cb_port>/v1/subscribeContext
     {
-        "entities": [
-            {
-                "type": "Restaurant",
-                "isPattern": "false",
-                "id": "LeBistro"
-            }
-        ],
-        "attributes": [ "average_scoring"  ],
-        "reference": "http://myapp.foo.com:1028/restaurant_average_scorings",
-        "duration": "P1M",
-        "notifyConditions": [
-            {
-                "type": "ONCHANGE",
-                "condValues": [
-                    "average_scoring"
-                ]
-            }
-        ]
+      "entities": [
+        {
+          "type": "Restaurant",
+          "isPattern": "false",
+          "id": "0115206c51f60b48b77e4c937835795c33bb953f"
+        }
+      ],
+      "attributes": [ "aggregateRating"  ],
+      "reference": "http://myapp.foo.com:1028/restaurant_average_scorings",
+      "duration": "P1M",
+      "notifyConditions": [
+        {
+          "type": "ONCHANGE",
+          "condValues": [
+              "aggregateRating"
+          ]
+        }
+      ]
     }
 
  

--- a/doc/development-context-aware-applications/how-to-update-and-query-context-information.md
+++ b/doc/development-context-aware-applications/how-to-update-and-query-context-information.md
@@ -4,163 +4,251 @@ exports, are said to play a **Context Producer** role.  As an example,
 let’s consider an application for rating restaurants (let’s call it
 NiceEating). The client part of that application running on the
 smartphone of users would play the role of Context Producer, enabling
-them to rate restaurants.
+them to review restaurants.
 
 On the other hand, processes running as part of your application
 architecture that query context information using REST operations that
 the Context Broker GE exports are said to play a **Context Consumer**
 role.  Continuing with our NiceEating app, the mobile application
 running on the smartphone of users and enabling them to query for the
-rating of restaurants would play the role of Context Consumer.  Note
+reviews of restaurants would play the role of Context Consumer.  Note
 that a given part of your application may play both the Context Producer
 and Context Consumer roles.  This would be the case of the mobile client
-of the NiceEating app enabling end users to rate, and query about rates
-of, restaurants.
+of the NiceEating app enabling end users to review and query about reviews
+of restaurants.
 
 Entities that would be relevant to the NiceEating application are of
-type Restaurant, Client and Rating. For example, when a given user
-scores a restaurant (e.g. in a scale from 0 to 5, “Client1234” scores
-“4” for the “LeBistro” restaurant) the smartphone application plays the
-Context Producer role **creating**a Rating entity by issuing the
-following HTTP request :
+type Restaurant, Client and Reviews. For example, when a given user
+reviews a restaurant (e.g. in a scale from 0 to 5, “Client1234” rates
+“4” for the “Elizalde” restaurant, which id is `0115206c51f60b48b77e4c937835795c33bb953f`, and describes his/her experience with "Cheap and nice place to eat.") the smartphone application plays the
+Context Producer role **creating** a Review entity by issuing the
+following HTTP request:
 
-    POST <cb_host>:<cb_port>/v1/contextEntities/type/Rating/id/LeBistro::Client1234
+    POST <cb_host>:<cb_port>/v1/contextEntities/type/Review/id/review-Elizalde-34
     {
-      "attributes" : [{
-          "name" : "score",
-          "type" : "integer",
-          "value" : "4"
+      "attributes":
+      [
+        {
+          "name": "author",
+          "type": "Person",
+          "value": "Client1234"
+        },
+        {
+          "name": "dateCreated",
+          "type": "date",
+          "value": "2016-04-20T18:19:33.00Z"
+        },
+        {
+          "name": "itemReviewed",
+          "type": "Restaurant",
+          "value": "0115206c51f60b48b77e4c937835795c33bb953f"
+        },
+        {
+          "name": "reviewBody",
+          "type": "none",
+          "value": "Cheap and nice place to eat."
+        },
+        {
+          "name": "reviewRating",
+          "type": "Rating",
+          "value": 4
         }
       ]
     }
 
-Each time a new Rating entity is created, the average rating for the
+Each time a new Review entity is created, the average rating for the
 corresponding restaurant is recalculated by the application backend
-which (playing also the role of Context Producer) **updates**the
-Restaurant entity accordingly:
+which (playing also the role of Context Producer) **updates** the
+Restaurant entity accordingly. For this example the user has reviewed the Elizalde restaurant:
 
-    PUT <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/LeBistro/attributes/average_scoring
+    PUT <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f/attributes/aggregateRating
     {
-       "value" : "4.2"
+      "value" : 4,
+      "reviewCount": 1
     }
 
 Finally, the user can get the information of a given Restaurant using
 the smartphone application. In that case the application works as
-Context Consumer, **querying**the Restaurant entity. For example, to get
-the average\_scoring attribute, the client application could query for
+Context Consumer, **querying** the Restaurant entity. For example, to get
+the aggregateRating attribute, the client application could query for
 it in the following way:
 
-    GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/LeBistro/attributes/average_scoring
-    //getting a JSON response such as the following one:
+    GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f/attributes/aggregateRating    
     {
       "attributes" : [
-      {
-        "name": "average_scoring",
-        "type": "float",
-        "value": "3.2"
-      }
+        {
+          "name" : "aggregateRating",
+          "type" : "none",
+          "value" : {
+            "reviewCount" : 1,
+            "ratingValue" : 4
+          }
+        }
       ],
       "statusCode" : {
         "code" : "200",
         "reasonPhrase" : "OK"
       }
-    } 
+    }
 
-You can also obtain the values of all attributes of the "LeBistro"
+
+You can also obtain the values of all attributes of the "Elizalde"
 restaurant in a single shot:
 
-    GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/LeBistro
 
-    //getting a JSON response such as the following one:
-
+    GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f
     {
-      "contextElement": {
-        "attributes": [
-        {
-          "name": "name",
-          "type": "string",
-          "value": "Le Bistro"
-        },
-        {
-          "name": "average_scoring",
-          "type": "float",
-          "value": "4.2"
-        },
-        {
-          "name": "location",
-          "type": "location",
-          "value": "40.419697, -3.691281",
-          "metadatas": [
+      "contextElement" : {
+        "type" : "Restaurant",
+        "isPattern" : "false",
+        "id" : "0115206c51f60b48b77e4c937835795c33bb953f",
+        "attributes" : [
           {
-            "name": "location",
-            "type": "string",
-            "value": "WGS84"
-          }
-        },
-        {
-          "name": "postal_address",
-          "type": "string",
-          "value": "Calle Alcala 57, 28028 Madrid, Spain"
-        },
-        {
-          "name": "cousine_type",
-          "type": "string",
-          "value": "french"
-        }
-        ],
-        "id": "LeBistro",
-        "isPattern": "false",
-        "type": "Restaurant"
-      },
-      "statusCode": {
-        "code": "200",
-        "reasonPhrase": "OK"
-      }
-    }
-
-Alternatively, if you want to get the **attributes as a key map instead
-of as a vector**, you can use the attributesFormat parameter, in the
-following way
-
-    GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/LeBistro?attributesFormat=object
-
-    //getting a JSON response such as the following one:
-    {
-      "contextElement": {
-        "attributes": {
-          "name": {     
-            "type": "string",
-            "value": "Le Bistro"
-          },
-          "average_scoring": {
-            "type": "float",
-            "value": "4.2"
-          },
-          "location": {
-            "type": "location",
-            "value": "40.419697, -3.691281",
-            "metadatas": [
-            {
-              "name": "location",
-              "type": "string",
-              "value": "WGS84"
+            "name" : "address",
+            "type" : "PostalAddress",
+            "value" : {
+              "streetAddress" : "Cuesta de las Cabras Aldapa 2",
+              "addressRegion" : "Araba",
+              "addressLocality" : "Alegría-Dulantzi",
+              "postalCode" : "01240"
             }
           },
-          "postal_address": {
-            "type": "string",
-            "value": "Calle Alcala 57, 28028 Madrid, Spain"
+          {
+            "name" : "aggregateRating",
+            "type" : "none",
+            "value" : {
+              "reviewCount" : 1,
+              "ratingValue" : 4
+            }
           },
-          "cousine_type": {
-            "type": "string",
-            "value": "french"
+          {
+            "name" : "capacity",
+            "type" : "PropertyValue",
+            "value" : 50
+          },
+          {
+            "name" : "department",
+            "type" : "none",
+            "value" : "Franchise1"
+          },
+          {
+            "name" : "description",
+            "type" : "none",
+            "value" : "Restaurante de estilo sidrería ubicado en Alegria-Dulantzi. Además ..."
+          },
+          {
+            "name" : "location",
+            "type" : "geo:point",
+            "value" : "42.8404625, -2.5123277"
+          },
+          {
+            "name" : "name",
+            "type" : "none",
+            "value" : "Elizalde"
+          },
+          {
+            "name" : "occupancyLevels",
+            "type" : "PropertyValue",
+            "value" : 0,
+            "metadatas" : [
+              {
+                "name" : "timestamp",
+                "type" : "date",
+                "value" : "2016-04-20T18:15:15.434Z"
+              }
+            ]
+          },
+          {
+            "name" : "priceRange",
+            "type" : "none",
+            "value" : 0
+          },
+          {
+            "name" : "telephone",
+            "type" : "none",
+            "value" : "945 400 868"
           }
-        },
-        "id": "LeBistro",
-        "isPattern": "false",
-        "type": "Restaurant"
+        ]
       },
-      "statusCode": {
-        "code": "200",
-        "reasonPhrase": "OK"
+      "statusCode" : {
+        "code" : "200",
+        "reasonPhrase" : "OK"
       }
     }
+
+
+
+Alternatively, if you want to get the **attributes as a key map instead
+of as a vector**, you can use the `attributesFormat` parameter, in the
+following way:
+
+    GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f?attributesFormat=object    
+    {
+      "contextElement" : {
+        "type" : "Restaurant",
+        "isPattern" : "false",
+        "id" : "0115206c51f60b48b77e4c937835795c33bb953f",
+        "attributes" : {
+          "address" : {
+            "type" : "PostalAddress",
+            "value" : {
+              "streetAddress" : "Cuesta de las Cabras Aldapa 2",
+              "addressRegion" : "Araba",
+              "addressLocality" : "Alegría-Dulantzi",
+              "postalCode" : "01240"
+            }
+          },
+          "aggregateRating" : {
+            "type" : "none",
+            "value" : {
+              "reviewCount" : 1,
+              "ratingValue" : 4
+            }
+          },
+          "capacity" : {
+            "type" : "PropertyValue",
+            "value" : 50
+          },
+          "department" : {
+            "type" : "none",
+            "value" : "Franchise1"
+          },
+          "description" : {
+            "type" : "none",
+            "value" : "Restaurante de estilo sidrería ubicado en Alegria-Dulantzi. Además ..."
+          },
+          "location" : {
+            "type" : "geo:point",
+            "value" : "42.8404625, -2.5123277"
+          },
+          "name" : {
+            "type" : "none",
+            "value" : "Elizalde"
+          },
+          "occupancyLevels" : {
+            "type" : "PropertyValue",
+            "value" : 0,
+            "metadatas" : [
+              {
+                "name" : "timestamp",
+                "type" : "date",
+                "value" : "2016-04-20T18:15:15.434Z"
+              }
+            ]
+          },
+          "priceRange" : {
+            "type" : "none",
+            "value" : 0
+          },
+          "telephone" : {
+            "type" : "none",
+            "value" : "945 400 868"
+          }
+        }
+      },
+      "statusCode" : {
+        "code" : "200",
+        "reasonPhrase" : "OK"
+      }
+    }
+

--- a/doc/development-context-aware-applications/introduction.md
+++ b/doc/development-context-aware-applications/introduction.md
@@ -4,9 +4,7 @@ consume context information at large scale and exploit it to transform
 your application into a truly smart application.  
 
 Context information is represented through values assigned to attributes
-that characterize those entities relevant to your application. [The
-Context Broker GE (open source reference implementation:
-Orion)](http://catalogue.fiware.org/enablers/publishsubscribe-context-broker-orion-context-broker)
+that characterize those entities relevant to your application. [The Context Broker GE (open source reference implementation: Orion)](http://catalogue.fiware.org/enablers/publishsubscribe-context-broker-orion-context-broker)
 is able to handle context information at large scale by implementing
 standard REST APIs. 
 


### PR DESCRIPTION
This PR updates the documentation related with Orion Context Broker. Now the documentation examples follow the model defined in the Tourguide Application.

A compiled version can be consulted at <http://testfiwaretour.readthedocs.org/en/refactor-orionv1-adapt_tourguide/development-context-aware-applications/introduction/>