### PR TITLE
Added empty lines between GET requests and payload responses

### DIFF
--- a/doc/development-context-aware-applications/how-to-update-and-query-context-information.md
+++ b/doc/development-context-aware-applications/how-to-update-and-query-context-information.md
@@ -74,6 +74,7 @@ the aggregateRating attribute, the client application could query for
 it in the following way:
 
     GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f/attributes/aggregateRating    
+    
     {
       "attributes" : [
         {
@@ -97,6 +98,7 @@ restaurant in a single shot:
 
 
     GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f
+    
     {
       "contextElement" : {
         "type" : "Restaurant",
@@ -183,6 +185,7 @@ of as a vector**, you can use the `attributesFormat` parameter, in the
 following way:
 
     GET <cb_host>:<cb_port>/v1/contextEntities/type/Restaurant/id/0115206c51f60b48b77e4c937835795c33bb953f?attributesFormat=object    
+    
     {
       "contextElement" : {
         "type" : "Restaurant",


### PR DESCRIPTION
Following the guidelines used for Orion NSGI V2, this PR adds an empty line between GET requests and their payload responses for the Orion NGSI V1 specification.

A compiled version can be consulted at <http://testfiwaretour.readthedocs.io/en/refactor-space_between_get_and_payload_response/development-context-aware-applications/how-to-update-and-query-context-information/>