### PR TITLE
Add Academy Links

### DIFF
--- a/docs/core/deep-dive.md
+++ b/docs/core/deep-dive.md
@@ -3,21 +3,20 @@
 Should you wish to learn much more about Core Context Management, please check
 out the following in depth documentation:
 
--   Read the full
-    [Orion documentation](https://fiware-orion.readthedocs.io/en/latest/)
+-   Read the full **documentation** for each Generic Enabler:
+    -   [Orion](https://fiware-orion.readthedocs.io/en/latest/)
+    -   [Cygnus ](https://fiware-cygnus.readthedocs.io/en/latest/)
+    -   [Draco](https://fiware-draco.readthedocs.io/en/latest/)
+    -   [QuantumLeap ](https://quantumleap.rtfd.io/)
+    -   [STH-Comet ](https://fiware-sth-comet.readthedocs.io/en/latest/)
 -   [FIWARE Harmonized Data Models](http://schema.fiware.org)
 -   [NGSI v2 Open API Specification](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/ngsiv2/ngsiv2-openapi.json)
-    <br/><br/>
--   Read the full
-    [Cygnus documentation](https://fiware-cygnus.readthedocs.io/en/latest/)
--   Read the full
-    [STH-Comet documentation](https://fiware-sth-comet.readthedocs.io/en/latest/)
--   Read the full [Quantum Leap documentation](https://quantumleap.rtfd.io/)
 
 ## Tutorials
 
-The following introductory Tutorials on the **Fundamentals of Core Context
-Management** are available:
+The following tutorials are available:
+
+<h4>Fundamentals of Core Context</h4>
 
 &nbsp; 101.
 [Getting Started](https://fiware-tutorials.readthedocs.io/en/latest/getting-started)<br/>
@@ -32,8 +31,7 @@ Management** are available:
 &nbsp; 106.
 [Subscribing to Changes in Context](https://fiware-tutorials.readthedocs.io/en/latest/subscriptions)<br/>
 
-Further Tutorials on **Core Context Management: History** persist historic
-context data:
+<h4>Core Context Management: History</h4>
 
 &nbsp; 301.
 [Persisting Context Data (Mongo-DB, MySQL, PostgreSQL)](https://fiware-tutorials.readthedocs.io/en/latest/historic-context)<br/>
@@ -41,6 +39,16 @@ context data:
 [Querying Time Series Data (Mongo-DB)](https://fiware-tutorials.readthedocs.io/en/latest/short-term-history)<br/>
 &nbsp; 303.
 [Querying Time Series Data (Crate-DB)](https://fiware-tutorials.readthedocs.io/en/latest/time-series-data)<br/>
+
+## Academy Courses
+
+Video tutorials and slide decks are available for the following Generic
+Enablers:
+
+-   [Orion](https://fiware-academy.readthedocs.io/en/latest/core/orion/)
+-   [Cygnus](https://fiware-academy.readthedocs.io/en/latest/core/cygnus/)
+-   [QuantumLeap](https://fiware-academy.readthedocs.io/en/latest/core/quantum-leap/)
+-   [STH-Comet](https://fiware-academy.readthedocs.io/en/latest/core/sth-comet/)
 
 ## Presentations
 
@@ -56,15 +64,12 @@ Presentations about Core Context Management from recent FIWARE Global Summits:
 -   Conversion from NGSI v1 -
     [NGSIv2 Overview for NGSIv1 Developers](http://bit.ly/ngsiv2-vs-ngsiv1)
 
-## GitHub Repositories and Docker Hub Images
+## GitHub
 
--   GitHub
-    -   [Orion (reference implementation)](https://github.com/telefonicaid/fiware-orion/)
-    -   [Cygnus (reference implementation)](https://github.com/ging/fiware-cygnus/)
-    -   [STH-Comet(reference implementation)](https://github.com/ging/fiware-sth-comet/)
-    -   [Quantum Leap](https://github.com/smartsdk/ngsi-timeseries-api/)
--   Docker
-    -   [Orion Docker Image](https://hub.docker.com/r/fiware/orion/)
-    -   [Cygnus Docker Image](https://hub.docker.com/r/ging/fiware-cygnus/)
-    -   [STH-Comet Docker Image](https://hub.docker.com/r/fiware/sth-comet/)
-    -   [Quantum Leap Docker Image](https://hub.docker.com/r/smartsdk/quantumleap/)
+Source code for all the Generic Enablers can be found within the FIWARE
+Catalogue GitHub repository:
+
+-   [Core Context Management](https://github.com/Fiware/catalogue/tree/master/core)
+
+The GitHub repository also includes additional information such as links to the
+official Docker Images

--- a/docs/core/deep-dive.md
+++ b/docs/core/deep-dive.md
@@ -5,10 +5,10 @@ out the following in depth documentation:
 
 -   Read the full **documentation** for each Generic Enabler:
     -   [Orion](https://fiware-orion.readthedocs.io/en/latest/)
-    -   [Cygnus ](https://fiware-cygnus.readthedocs.io/en/latest/)
+    -   [Cygnus](https://fiware-cygnus.readthedocs.io/en/latest/)
     -   [Draco](https://fiware-draco.readthedocs.io/en/latest/)
-    -   [QuantumLeap ](https://quantumleap.rtfd.io/)
-    -   [STH-Comet ](https://fiware-sth-comet.readthedocs.io/en/latest/)
+    -   [QuantumLeap](https://quantumleap.rtfd.io/)
+    -   [STH-Comet](https://fiware-sth-comet.readthedocs.io/en/latest/)
 -   [FIWARE Harmonized Data Models](http://schema.fiware.org)
 -   [NGSI v2 Open API Specification](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/ngsiv2/ngsiv2-openapi.json)
 

--- a/docs/data-publication/deep-dive.md
+++ b/docs/data-publication/deep-dive.md
@@ -1,19 +1,28 @@
-Should you wish to learn much more about publishing Open Data, please check:
+## Documentation
 
--   **Extensions to CKAN**:
+Should you wish to learn much more about publishing Open Data, please check the
+following:
 
-    -   [GitHub repository (reference implementation)](https://github.com/conwetlab/FIWARE-CKAN-Extensions)
-    -   [Play with the Docker container](https://hub.docker.com/r/fiware/ckan/)
-    -   [Browse the API](http://docs.ckan.apiary.io/)
-    -   [Read the full documentation](http://docs.ckan.org/en/latest/)
-    -   [Latest stable release](https://github.com/conwetlab/FIWARE-CKAN-Extensions/releases/latest)
+-   Read the full **documentation** for each Generic Enabler:
 
--   **Biz Ecosystem**:
-    -   [GitHub repository (reference implementation)](https://github.com/FIWARE-TMForum/Business-API-Ecosystem)
-    -   [Play with the Docker container](https://hub.docker.com/r/fiware/business-api-ecosystem/)
-    -   [Browse the API](http://docs.fiwaretmfbizecosystem.apiary.io/#)
-    -   [Read the full documentation](http://business-api-ecosystem.readthedocs.io/en/latest/)
-    -   [Latest stable release](https://github.com/FIWARE-TMForum/Business-API-Ecosystem/releases/latest)
+    -   [Biz Ecosystem](http://business-api-ecosystem.readthedocs.io/en/latest/)
+    -   [Extensions to CKAN](http://docs.ckan.org/en/latest/)
+    -   [Idra](https://idra.rtfd.io/)
+    -   [APInf](https://github.com/apinf/platform/blob/develop/README.md)
+
+-   Read the Apiary Documentation:
+
+    -   [Biz Ecosystem](http://docs.fiwaretmfbizecosystem.apiary.io/#)
+    -   [Extensions to CKAN](http://docs.ckan.apiary.io/)
+
+## Academy Courses
+
+Video tutorials and slide decks are available for the following Generic
+Enablers:
+
+-   [Biz Ecosystem](https://fiware-academy.readthedocs.io/en/latest/data-publication/business-api/)
+-   [Extensions to CKAN](https://fiware-academy.readthedocs.io/en/latest/data-publication/ckan/)
+-   [APInf](https://fiware-academy.readthedocs.io/en/latest/data-publication/apinf/)
 
 ## Presentations
 
@@ -23,3 +32,13 @@ Presentations about Open Data from recent FIWARE Global Summits:
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | [Publishing Context Information](https://www.slideshare.net/FI-WARE/fiware-global-summit-publishing-context-information-as-righttime-open-data) | [Publishing Open Data](https://www.slideshare.net/FI-WARE/fiware-tech-summit-francisco-de-la-vega-publishing-context-info-as-open-data) |
 |                                                                                                                                                 | [Implementing CKAN Extensions](https://www.slideshare.net/FI-WARE/fiware-tech-summit-empower-your-ckan)                                 |
+
+## GitHub
+
+Source code for all the Generic Enablers can be found within the FIWARE
+Catalogue GitHub repository:
+
+-   [Data Publication & Monentization](https://github.com/Fiware/catalogue/tree/master/data-publication)
+
+The GitHub repository also includes additional information such as links to the
+official Docker Images

--- a/docs/iot-agents/deep-dive.md
+++ b/docs/iot-agents/deep-dive.md
@@ -1,27 +1,40 @@
 ## Documentation
 
-Should you wish to learn much more about connecting to IoT, please check out the
-following in-depth documentation about IoT Agents:
+Should you wish to learn much more about connecting to IoT, robotics or
+third-party systems, please check out the following in-depth documentation about
+IoT Agents:
 
--   Read the full
-    [IoT Agent library documentation](https://iotagent-node-lib.readthedocs.io/en/latest)
--   [IoT Agent library Open API Specification](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/iot.IoTagent-node-lib/IoTagent-node-lib-openapi.json)
-    <br/><br/>
--   [IoTAgent-JSON](http://fiware-iotagent-json.readthedocs.io/en/latest/) - a
-    bridge between HTTP/MQTT messaging (with a JSON payload) and NGSI
--   [IoTAgent-LWM2M](http://fiware-iotagent-lwm2m.readthedocs.io/en/latest) - a
-    bridge between the
-    [Lightweight M2M](https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/)
-    protocol and NGSI
--   [IoTAgent-UL](http://fiware-iotagent-ul.readthedocs.io/en/latest) - a bridge
-    between HTTP/MQTT messaging (with an UltraLight2.0 payload) and NGSI
--   [IoTagent-LoRaWAN](http://fiware-lorawan.readthedocs.io/en/latest) - a
-    bridge between the [LoRaWAN](https://www.thethingsnetwork.org/docs/lorawan/)
-    protocol and NGSI
+-   Read the full IoT Agent library
+    [documentation](https://iotagent-node-lib.readthedocs.io/en/latest)
+-   IoT Agent library
+    [Open API Specification](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/iot.IoTagent-node-lib/IoTagent-node-lib-openapi.json)
+-   Read the full **documentation** for each IoT Agent:
+    -   [IoTAgent-JSON](http://fiware-iotagent-json.readthedocs.io/en/latest/) -
+        a bridge between HTTP/MQTT messaging (with a JSON payload) and NGSI
+    -   [IoTAgent-LWM2M](http://fiware-iotagent-lwm2m.readthedocs.io/en/latest) -
+        a bridge between the
+        [Lightweight M2M](https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/)
+        protocol and NGSI
+    -   [IoTAgent-UL](http://fiware-iotagent-ul.readthedocs.io/en/latest) - a
+        bridge between HTTP/MQTT messaging (with an UltraLight2.0 payload) and
+        NGSI
+    -   [IoTagent-LoRaWAN](http://fiware-lorawan.readthedocs.io/en/latest) - a
+        bridge between the
+        [LoRaWAN](https://www.thethingsnetwork.org/docs/lorawan/) protocol and
+        NGSI
+    -   [IoT Agent for OPC-UA](https://iotagent-opcua.rtfd.io/) - a bridge
+        between the [OPC Unified Architecture](http://www.opcua.us/) protocol
+        and NGSI
+-   Read the OpenMTC [documentation](http://www.openmtc.org/doc.html) - document
+    exchange
+-   Read the Fast-RTPS [documentation](https://eprosima-fast-rtps.rtfd.io/) -
+    robotics
 
 ## Tutorials
 
-The following Tutorials on **IoT Agents** also are available:
+The following tutorials are available:
+
+<h4>IoT Agents</h4>
 
 &nbsp; 201.
 [Introduction to IoT Sensors](https://fiware-tutorials.readthedocs.io/en/latest/iot-sensors)<br/>
@@ -29,6 +42,20 @@ The following Tutorials on **IoT Agents** also are available:
 [Provisioning an IoT Agent](https://fiware-tutorials.readthedocs.io/en/latest/iot-agent)<br/>
 &nbsp; 203.
 [IoT over MQTT](https://fiware-tutorials.readthedocs.io/en/latest/iot-over-mqtt)<br/>
+
+<h4>Robotics</h4>
+
+&nbsp; 250.
+[Introduction to Fast-RTPS and Micro-RTPS ](https://fiware-tutorials.readthedocs.io/en/latest/fast-rtps-micro-rtps)<br/>
+
+## Academy Courses
+
+Video tutorials and slide decks are available for the following Generic
+Enablers:
+
+-   [IoT Agents](https://fiware-academy.readthedocs.io/en/latest/iot-agents/idas/)
+-   [Domibus](https://fiware-academy.readthedocs.io/en/latest/third-party/domibus/)
+-   [Fast-RTPS](https://fiware-academy.readthedocs.io/en/latest/robotics/fast-rtps/)
 
 ## Presentations
 
@@ -45,30 +72,17 @@ Presentations about IoT Agents and Sensors from recent FIWARE Global Summits:
 | [OPC UA Agent](https://www.slideshare.net/FI-WARE/fiware-global-summit-opc-ua-agent-97030170)                                              |                                                                                                                                          |
 | [OpenMTC - OneM2M](https://www.slideshare.net/FI-WARE/fiware-tech-summit-openmtc-onem2m-middleware)                                        |                                                                                                                                          |
 
-## GitHub Repositories
+## GitHub
 
--   [IoT Agent for JSON](https://github.com/telefonicaid/iotagent-json) - a
-    bridge between HTTP/MQTT messaging (with a JSON payload) and NGSI
--   [IoT Agent for LWM2M](https://github.com/telefonicaid/lightweightm2m-iotagent) -
-    a bridge between the
-    [Lightweight M2M](https://www.omaspecworks.org/what-is-oma-specworks/iot/lightweight-m2m-lwm2m/)
-    protocol and NGSI
--   [IoT Agent for Ultralight](https://github.com/telefonicaid/iotagent-ul) - a
-    bridge between HTTP/MQTT messaging (with an UltraLight2.0 payload) and NGSI
--   [IoT Agent for LoRaWAN](https://github.com/Atos-Research-and-Innovation/IoTagent-LoRaWAN) -
-    a bridge between the
-    [LoRaWAN](https://www.thethingsnetwork.org/docs/lorawan/) protocol and NGSI
--   [IoT Agent library](https://github.com/telefonicaid/iotagent-node-lib/) -
-    library for developing your own IoT Agent.
+Source code for all the Generic Enablers can be found within the FIWARE
+Catalogue GitHub repository:
 
--   The [Fast RTPS](https://github.com/eProsima/Fast-RTPS) Incubated Generic
-    Enabler has been adopted as default middleware in ROS2, the widely known
-    Robot Operating System, therefore it helps to interface with robotics
-    systems.
--   The [OpenMTC](https://github.com/OpenMTC/OpenMTC) Incubated Generic Enabler
-    brings an open source implementation of the OneM2M standard. A northbound
-    interface with the Orion Context Broker is implemented as part of the
-    product.
+-   [IoT Agents](https://github.com/Fiware/catalogue/tree/master/iot-agents)
+-   [Robotics](https://github.com/Fiware/catalogue/tree/master/robotics)
+-   [Third Party](https://github.com/Fiware/catalogue/tree/master/third-party)
+
+The GitHub repository also includes additional information such as links to the
+official Docker Images
 
 There are existing
 [IoT Agents instances up and running](https://catalogue.fiware.org/enablers/backend-device-management-idas/instances)

--- a/docs/processing/cosmos/deep-dive.md
+++ b/docs/processing/cosmos/deep-dive.md
@@ -11,6 +11,12 @@ following:
     -   [Read the full documentation](https://fiware-cosmos-flink.readthedocs.io)
     -   [Latest stable release](https://github.com/ging/fiware-cosmos-orion-flink-connector/releases/latest)
 
+## Academy Courses
+
+Video tutorials and slide decks are available for the Cosmos Generic Enabler:
+
+-   [Cosmos](https://fiware-academy.readthedocs.io/en/latest/processing/cosmos/)
+
 ## Presentations
 
 Presentations about Data Analysis from recent FIWARE Global Summits:

--- a/docs/processing/kurento/deep-dive.md
+++ b/docs/processing/kurento/deep-dive.md
@@ -14,6 +14,13 @@ the following Tutorials on the **Media Streams** also are available:
 &nbsp; 503.
 [Introduction to Media Streams](https://fiware-tutorials.readthedocs.io/en/latest/media-streams)<br/>
 
+## Academy Courses
+
+Video tutorials and slide decks are available for the following Generic
+Enablers:
+
+-   [Kurento](https://fiware-academy.readthedocs.io/en/latest/processing/kurento)
+
 ## Presentations
 
 Presentations about Media Streams from recent FIWARE Global Summits:
@@ -22,15 +29,12 @@ Presentations about Media Streams from recent FIWARE Global Summits:
 | --------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
 | [Real-time media processing](https://www.slideshare.net/FI-WARE/fiware-global-summit-realtime-media-stream-processing-using-kurento-97030173) | [Stream Processing with Kurento](https://www.slideshare.net/FI-WARE/fiware-tech-summit-stream-processing-with-kurento-media-server) |
 
-## Video Presentations
+## GitHub
 
--   [Part 1 - Kurento main concepts](https://www.youtube.com/watch?v=1EKV1wpz4iU)
--   [Part 2 - Installation guide](https://www.youtube.com/watch?v=I-qAFViQfBk)
--   [Part 3 - Development guide](https://www.youtube.com/watch?v=rloBE438avU)
--   [Part 4 - Kurento and the FILAB](https://www.youtube.com/watch?v=U-_vh03g5cs)
+Source code for the Kurento Generic Enabler can be found within the FIWARE
+Catalogue GitHub repository:
 
-## GitHub Repositories and Docker Hub Images
+-   [Processing](https://github.com/Fiware/catalogue/tree/master/processing#kurento)
 
--   [GitHub repository (reference implementation)](https://github.com/Kurento/kurento-media-server)
--   [Play with the Docker container](https://hub.docker.com/r/fiware/stream-oriented-kurento/)
--   [Latest stable release](https://github.com/Kurento/kurento-media-server/releases/latest)
+The GitHub repository also includes additional information such as links to the
+official Docker Images

--- a/docs/security/deep-dive.md
+++ b/docs/security/deep-dive.md
@@ -3,17 +3,17 @@
 Should you wish to learn much more about security, please check out the
 following in depth documentation:
 
--   Read the full
-    [Keyrock documentation](http://fiware-idm.readthedocs.org/en/latest/)
+-   Read the full **documentation** for each enabler:
+    -   [AuthZForce](http://authzforce-ce-fiware.readthedocs.org/en/latest/)
+    -   [Keyrock](http://fiware-idm.readthedocs.org/en/latest/)
+    -   [PEP Proxy](http://fiware-pep-proxy.readthedocs.org/en/stable/)
 -   [Keyrock Open API Specification](https://swagger.lab.fiware.org/?url=https://raw.githubusercontent.com/Fiware/specifications/master/OpenAPI/security.Idm/Idm-openapi.json)
--   Read the full
-    [AuthZForce documentation](http://authzforce-ce-fiware.readthedocs.org/en/latest/)
--   Read the full
-    [PEP Proxy documentation](http://fiware-pep-proxy.readthedocs.org/en/stable/)
 
 ## Tutorials
 
-The following Tutorials on **Security** also are available:
+The following tutorials are available:
+
+<h4>Security</h4>
 
 &nbsp; 401.
 [Administrating Users and Organizations](https://fiware-tutorials.readthedocs.io/en/latest/identity-management)<br/>
@@ -21,6 +21,17 @@ The following Tutorials on **Security** also are available:
 [Managing Roles and Permissions](https://fiware-tutorials.readthedocs.io/en/latest/roles-permissions)<br/>
 &nbsp; 403.
 [Securing Application Access](https://fiware-tutorials.readthedocs.io/en/latest/securing-access)<br/>
+&nbsp; 404.
+[Securing Microservices with a PEP Proxy](https://fiware-tutorials.readthedocs.io/en/latest/pep-proxy)<br/>
+
+## Academy Courses
+
+Video tutorials and slide decks are available for the following Generic
+Enablers:
+
+-   [Authzforce](https://fiware-academy.readthedocs.io/en/latest/security/authzforce/)
+-   [Keyrock](https://fiware-academy.readthedocs.io/en/latest/security/authzforce/)
+-   [Wilma](https://fiware-academy.readthedocs.io/en/latest/security/authzforce/)
 
 ## Presentations
 
@@ -30,24 +41,12 @@ Presentations about Security from recent FIWARE Global Summits:
 | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [API Management](https://www.slideshare.net/FI-WARE/fiware-global-summit-fiwares-api-management-97030121) | [Identity Management, Access Control and API Management](https://www.slideshare.net/FI-WARE/fiware-alvaro-alonso-complete-framework-for-identity-access-control-and-api-management) |
 
-## Video Presentations
+## GitHub
 
--   Keyrock
-    -   [Part 1 - Keyrock Introduction](https://www.youtube.com/watch?v=dHyVTan6bUY)
-    -   [Part 2 - Keyrock Overview](https://www.youtube.com/watch?v=dtKsjGbJ7X)
-    -   [Part 3 - Applications in Keyrock](https://www.youtube.com/watch?v=pjsl0eHpFww)
--   PEP Proxy
-    -   [Part 1 - PEP Proxy Introduction](https://www.youtube.com/watch?v=8tGbUI18udM)
-    -   [Part 2 - PEP Proxy Installation, Registration and Configuration](https://www.youtube.com/watch?v=b4sYU78skrw)
-    -   [Part 3 - Securing an API](https://www.youtube.com/watch?v=coxFQEY0_So)
+Source code for all the Generic Enablers can be found within the FIWARE
+Catalogue GitHub repository:
 
-## GitHub Repositories and Docker Hub Images
+-   [Security](https://github.com/Fiware/catalogue/tree/master/security)
 
--   GitHub
-    -   [Keyrock (reference implementation)](https://github.com/ging/fiware-idm/)
-    -   [AuthZForce (reference implementation)](https://github.com/authzforce/server)
-    -   [PEP Proxy (reference implementation)](https://github.com/ging/fiware-pep-proxy)
--   Docker
-    -   [Keyrock Docker Image](https://hub.docker.com/r/fiware/idm/)
-    -   [AuthZForce Docker Image](https://hub.docker.com/r/fiware/authzforce-ce-server/)
-    -   [PEP Proxy Docker container](https://hub.docker.com/r/fiware/pep-proxy/)
+The GitHub repository also includes additional information such as links to the
+official Docker Images

--- a/docs/visualization/deep-dive.md
+++ b/docs/visualization/deep-dive.md
@@ -13,6 +13,14 @@ following in depth documentation:
 -   [Knowage CE Manual](http://download.forge.ow2.org/knowage/Knowage_6.x_CE_Manual.pdf)
 -   [Knowage API Specification](https://knowage.docs.apiary.io/)
 
+## Academy Courses
+
+Video tutorials and slide decks are available for the following Generic
+Enablers:
+
+-   [Wirecloud](https://fiware-academy.readthedocs.io/en/latest/processing/wirecloud/)
+-   [Knowage](https://fiware-academy.readthedocs.io/en/latest/processing/knowage/)
+
 ## Presentations
 
 Presentations about Data Visualization from recent FIWARE Global Summits:
@@ -22,11 +30,12 @@ Presentations about Data Visualization from recent FIWARE Global Summits:
 | [Business Analytics using Knowage](https://www.slideshare.net/FI-WARE/fiware-global-summit-business-intelligence-using-knowage-97030885) | [Building Wirecloud Real-time Dashboards](https://www.slideshare.net/FI-WARE/fiware-tech-summit-miguel-jimenez-building-realtime-dashboards-to-monitor-context) |
 |                                                                                                                                          | [Building Professional Dashboards in Minutes](https://www.slideshare.net/FI-WARE/fiware-tech-summit-professional-dashboards-for-dummies)                        |
 
-## GitHub Repositories and Docker Hub Images
+## GitHub
 
--   GitHub
-    -   [Wirecloud (reference implementation)](https://github.com/Wirecloud/wirecloud)
-    -   [Knowage (reference implementation)](https://github.com/KnowageLabs/Knowage-Server)
--   Docker
-    -   [Wirecloud Docker Image](https://hub.docker.com/r/fiware/wirecloud/)
-    -   [Knowage Docker Image](https://hub.docker.com/r/fiware/knowage-server-docker/)
+Source code for all the Generic Enablers can be found within the FIWARE
+Catalogue GitHub repository:
+
+-   [Visualization](https://github.com/Fiware/catalogue/tree/master/processing)
+
+The GitHub repository also includes additional information such as links to the
+official Docker Images


### PR DESCRIPTION
* List Docs for all GEs
* Add new Academy Links
* Add GitHub Catalog Links
* Remove duplicated deep-dive links to reduce maintenance overhead - funnelled to academy
* Remove direct Docker and GitHub links to reduce maintenance overhead - funnelled to catalogue